### PR TITLE
add vector- and vss-path to injected variables on async

### DIFF
--- a/elisa.el
+++ b/elisa.el
@@ -1162,6 +1162,8 @@ Call ON-DONE callback with result as an argument after FUNC evaluation done."
 		    ,(async-inject-variables "elisa-reranker-enabled")
 		    ,(async-inject-variables "load-path")
 		    ,(async-inject-variables "Info-directory-list")
+		    ,(async-inject-variables "elisa-sqlite-vector-path")
+		    ,(async-inject-variables "elisa-sqlite-vss-path")
 		    (require 'elisa)
 		    (,func))
 		 (lambda (res)


### PR DESCRIPTION
I'm running emacs on nixos and had a fun time figuring out why I have issues with some of the commands. Figured out that those two variables are not injected into the async process which then cannot locate the libraries even they work in the main instance.