### PR TITLE
Speed up semantic splitting with batch embeddings

### DIFF
--- a/README.org
+++ b/README.org
@@ -305,6 +305,10 @@ Example configuration.
     * Type: String
     * Description: Template used for rewriting prompts for better retrieval.
 
++ ~elisa-batch-embeddings-enabled~:
+    * Type: Boolean
+    * Description: Enable batch embeddings if supported.
+
 **** Web Search and Integration
 
 + ~elisa-searxng-url~:

--- a/elisa.el
+++ b/elisa.el
@@ -455,6 +455,14 @@ FOREIGN KEY(collection_id) REFERENCES collections(rowid)
   "Calculate breakpoint threshold for DISTANCES based on K standard deviations."
   (+ (elisa-avg distances) (* k (elisa-std-dev distances))))
 
+(defun elisa-embeddings (chunks)
+  "Calculate embeddings for CHUNKS.
+Return list of vectors."
+  (let ((provider elisa-embeddings-provider))
+    (if (member 'embeddings-batch (llm-capabilities provider))
+	(llm-batch-embeddings provider chunks)
+      (mapcar (lambda (chunk) (llm-embedding provider chunk)) chunks))))
+
 (defun elisa-parse-info-manual (name collection-name)
   "Parse info manual with NAME and save index to COLLECTION-NAME."
   (with-temp-buffer

--- a/elisa.el
+++ b/elisa.el
@@ -275,6 +275,10 @@ If set, all quotes with similarity less than threshold will be filtered out."
   "Supported complex document file extensions."
   :type '(repeat string))
 
+(defcustom elisa-batch-embeddings-enabled nil
+  "Enable batch embeddings if supported."
+  :type 'boolean)
+
 (defun elisa-supported-complex-document-p (path)
   "Check if PATH contain supported complex document."
   (cl-find (file-name-extension path)
@@ -467,7 +471,8 @@ FOREIGN KEY(collection_id) REFERENCES collections(rowid)
   "Calculate embeddings for CHUNKS.
 Return list of vectors."
   (let ((provider elisa-embeddings-provider))
-    (if (member 'embeddings-batch (llm-capabilities provider))
+    (if (and elisa-batch-embeddings-enabled
+	     (member 'embeddings-batch (llm-capabilities provider)))
 	(llm-batch-embeddings provider chunks)
       (mapcar (lambda (chunk) (llm-embedding provider chunk)) chunks))))
 
@@ -1259,6 +1264,7 @@ Call ON-DONE callback with result as an argument after FUNC evaluation done."
 		    ,(async-inject-variables "elisa-find-executable")
 		    ,(async-inject-variables "elisa-tar-executable")
 		    ,(async-inject-variables "elisa-prompt-rewriting-enabled")
+		    ,(async-inject-variables "elisa-batch-embeddings-enabled")
 		    ,(async-inject-variables "elisa-rewrite-prompt-template")
 		    ,(async-inject-variables "elisa-semantic-split-function")
 		    ,(async-inject-variables "elisa-webpage-extraction-function")

--- a/elisa.el
+++ b/elisa.el
@@ -878,8 +878,11 @@ When FORCE parse even if already parsed."
 		     (elisa-parse-directory
 		      (expand-file-name dir)))))
 
+(defvar eww-accept-content-types)
+
 (defun elisa-search-duckduckgo (prompt)
   "Search duckduckgo for PROMPT and return list of urls."
+  (require 'eww)
   (let* ((url (format "https://duckduckgo.com/html/?q=%s" (url-hexify-string prompt)))
 	 (buffer-name (plz 'get url :as 'buffer
 			:headers `(("Accept" . ,eww-accept-content-types)
@@ -973,6 +976,7 @@ You can customize `elisa-searxng-url' to use non local instance."
 
 (defun elisa-get-webpage-buffer (url)
   "Get buffer with URL content."
+  (require 'eww)
   (let ((buffer-name (ignore-errors
 		       (plz 'get url :as 'buffer
 			 :headers `(("Accept" . ,eww-accept-content-types)

--- a/elisa.el
+++ b/elisa.el
@@ -5,7 +5,7 @@
 ;; Author: Sergey Kostyaev <sskostyaev@gmail.com>
 ;; URL: http://github.com/s-kostyaev/elisa
 ;; Keywords: help local tools
-;; Package-Requires: ((emacs "29.2") (ellama "0.11.2") (llm "0.9.1") (async "1.9.8") (plz "0.9"))
+;; Package-Requires: ((emacs "29.2") (ellama "0.11.2") (llm "0.18.1") (async "1.9.8") (plz "0.9"))
 ;; Version: 1.1.1
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;; Created: 18th Feb 2024


### PR DESCRIPTION
Added `elisa-embeddings` function for calculating embeddings for chunks. If the LLM provider supports batch embeddings, use them; otherwise, calculate embeddings individually using `llm-embedding`.

Wait for https://github.com/ahyatt/llm/pull/109 to prevent recommended configuration breaking.