### PR TITLE
Fix typo in command name - missing `a` in `elisa-disble-all-collections`

### DIFF
--- a/README.org
+++ b/README.org
@@ -195,7 +195,7 @@ Enable all collections.
 
 Disable collection.
 
-*** elisa-disble-all-collections
+*** elisa-disable-all-collections
 
 Disable all collections.
 

--- a/elisa.el
+++ b/elisa.el
@@ -1358,7 +1358,7 @@ It does nothing if buffer file not inside one of existing collections."
 	  (cl-remove col elisa-enabled-collections :test #'string=))))
 
 ;;;###autoload
-(defun elisa-disble-all-collections ()
+(defun elisa-disable-all-collections ()
   "Disable all collections."
   (interactive)
   (mapc #'elisa-disable-collection elisa-enabled-collections))


### PR DESCRIPTION
Fix #34 