### PR TITLE
Fix validate function syntax in custom variables

### DIFF
--- a/elisa.el
+++ b/elisa.el
@@ -117,14 +117,14 @@
 					    (make-llm-ollama
 					     :embedding-model "nomic-embed-text"))
   "Embeddings provider to generate embeddings."
-  :type '(sexp :validate 'llm-standard-provider-p))
+  :type '(sexp :validate llm-standard-provider-p))
 
 (defcustom elisa-chat-provider (progn (require 'llm-ollama)
 				      (make-llm-ollama
 				       :chat-model "sskostyaev/openchat:8k-rag"
 				       :embedding-model "nomic-embed-text"))
   "Chat provider."
-  :type '(sexp :validate 'llm-standard-provider-p))
+  :type '(sexp :validate llm-standard-provider-p))
 
 (defcustom elisa-db-directory (file-truename
 			       (file-name-concat


### PR DESCRIPTION
Fixed the syntax for the `:validate` parameter in
`elisa-embedding-provider` and `elisa-chat-provider` custom variables by removing the single quote around the function name.